### PR TITLE
Updates examples to use UIWindow when Spices disabled

### DIFF
--- a/Examples/UIKitExample/SceneDelegate.swift
+++ b/Examples/UIKitExample/SceneDelegate.swift
@@ -15,7 +15,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         #if DEBUG
         window = SpiceEditorWindow(windowScene: windowScene, editing: AppSpiceStore.shared)
         #else
-        window = SpiceEditorWindow(windowScene: windowScene)
+        window = UIWindow(windowScene: windowScene)
         #endif
         window?.rootViewController = makeRootViewController()
         window?.makeKeyAndVisible()

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         #if DEBUG
         window = SpiceEditorWindow(windowScene: windowScene, editing: AppSpiceStore.shared)
         #else
-        window = SpiceEditorWindow(windowScene: windowScene)
+        window = UIWindow(windowScene: windowScene)
         #endif
         window?.rootViewController = ViewController()
         window?.makeKeyAndVisible()

--- a/Sources/Spices/SpiceEditorWindow.swift
+++ b/Sources/Spices/SpiceEditorWindow.swift
@@ -17,7 +17,7 @@ import UIKit
 /// #if DEBUG
 /// window = SpiceEditorWindow(windowScene: windowScene, editing: AppSpiceStore.shared)
 /// #else
-/// window = SpiceEditorWindow(windowScene: windowScene)
+/// window = UIWindow(windowScene: windowScene)
 /// #endif
 /// ```
 open class SpiceEditorWindow: UIWindow {


### PR DESCRIPTION
Updates the example code, documentation, and README to use an instance of UIWindow when Spices is not enabled.