### PR TITLE
Add support for String settings

### DIFF
--- a/Examples/SwiftUIExample/AppSpiceStore.swift
+++ b/Examples/SwiftUIExample/AppSpiceStore.swift
@@ -8,6 +8,7 @@ enum ServiceEnvironment: String, CaseIterable {
 
 final class AppSpiceStore: SpiceStore {
     @Spice(requiresRestart: true) var environment: ServiceEnvironment = .production
+    @Spice(name: "API URL") var apiURL = "http://example.com"
     @Spice var enableLogging = false
     @Spice var clearCache = {
         try await Task.sleep(for: .seconds(1))

--- a/Examples/SwiftUIExample/ContentView.swift
+++ b/Examples/SwiftUIExample/ContentView.swift
@@ -19,6 +19,9 @@ struct ContentView: View {
                     LabeledContent("Environment") {
                         Text(String(describing: spiceStore.environment))
                     }
+                    LabeledContent("API URL") {
+                        Text(spiceStore.apiURL)
+                    }
                     LabeledContent("Enable Logging") {
                         Text(spiceStore.enableLogging ? "Yes" : "No")
                     }

--- a/Examples/UIKitExample/AppSpiceStore.swift
+++ b/Examples/UIKitExample/AppSpiceStore.swift
@@ -11,6 +11,7 @@ final class AppSpiceStore: SpiceStore {
     static let shared = AppSpiceStore()
 
     @Spice(requiresRestart: true) var environment: ServiceEnvironment = .production
+    @Spice(name: "API URL") var apiURL = "http://example.com"
     @Spice var enableLogging = false
     @Spice var clearCache = {
         try await Task.sleep(for: .seconds(1))

--- a/Examples/UIKitExample/ContentViewController.swift
+++ b/Examples/UIKitExample/ContentViewController.swift
@@ -92,13 +92,17 @@ private extension ContentViewController {
             .text(
                 "This is an example app showcasing the Spices framework."
                 + "\n\n"
-                + "The following illustrates how spices can be observed using SwiftUI."
+                + "The following illustrates how spices can be observed using Combine from UIKit."
             )
         ]
         let generalItems: [Item] = [
             .titleValue(
                 title: "Environment",
                 value: String(describing: spiceStore.environment)
+            ),
+            .titleValue(
+                title: "API URL",
+                value: spiceStore.apiURL
             ),
             .titleValue(
                 title: "Enable Logging",
@@ -127,10 +131,11 @@ private extension ContentViewController {
         Publishers.CombineLatest4(
             spiceStore.$environment,
             spiceStore.$enableLogging,
-            spiceStore.featureFlags.$notifications,
-            spiceStore.featureFlags.$fastRefreshWidgets
+            spiceStore.$apiURL,
+            spiceStore.featureFlags.$notifications
         )
-        .sink { [weak self] _, _, _, _ in
+        .combineLatest(spiceStore.featureFlags.$fastRefreshWidgets)
+        .sink { [weak self] _, _ in
             self?.updateSnapshot()
         }
         .store(in: &cancellables)

--- a/Sources/Spices/Internal/MenuItems/TextFieldMenuItem.swift
+++ b/Sources/Spices/Internal/MenuItems/TextFieldMenuItem.swift
@@ -1,0 +1,39 @@
+//
+//  TextFieldMenuItem.swift
+//  Spices
+//
+//  Created by Harlan Haskins on 2/25/25.
+//
+
+
+import Combine
+import Foundation
+
+final class TextFieldMenuItem: MenuItem, ObservableObject {
+    let id = UUID().uuidString
+    let name: Name
+    let requiresRestart: Bool
+    @Published var value: String {
+        didSet {
+            if value != storage.value {
+                storage.value = value
+            }
+        }
+    }
+
+    private let storage: AnyStorage<String>
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(name: Name, requiresRestart: Bool, storage: AnyStorage<String>) {
+        self.name = name
+        self.requiresRestart = requiresRestart
+        self.storage = storage
+        self.value = storage.value
+        storage.publisher.sink { [weak self] newValue in
+            if newValue != self?.value {
+                self?.value = newValue
+            }
+        }
+        .store(in: &cancellables)
+    }
+}

--- a/Sources/Spices/Internal/Views/MenuItemView.swift
+++ b/Sources/Spices/Internal/Views/MenuItemView.swift
@@ -10,6 +10,8 @@ struct MenuItemView: View {
             ToggleMenuItemView(menuItem: menuItem)
         } else if let menuItem = menuItem as? PickerMenuItem {
             PickerMenuItemView(menuItem: menuItem)
+        } else if let menuItem = menuItem as? TextFieldMenuItem {
+            TextFieldMenuItemView(menuItem: menuItem)
         } else if let menuItem = menuItem as? ButtonMenuItem {
             ButtonMenuItemView(menuItem: menuItem)
         } else if let menuItem = menuItem as? AsyncButtonMenuItem {

--- a/Sources/Spices/Internal/Views/TextFieldMenuItemView.swift
+++ b/Sources/Spices/Internal/Views/TextFieldMenuItemView.swift
@@ -1,0 +1,38 @@
+//
+//  ToggleMenuItemView 2.swift
+//  Spices
+//
+//  Created by Harlan Haskins on 2/25/25.
+//
+
+
+import SwiftUI
+
+struct TextFieldMenuItemView: View {
+    @ObservedObject var menuItem: TextFieldMenuItem
+
+    @State private var editingValue: String = ""
+    @State private var restartApp = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            HStack {
+                Text(menuItem.name.rawValue)
+                Spacer()
+                TextField("Value", text: $editingValue)
+                    .multilineTextAlignment(.trailing)
+                    .submitLabel(.done)
+                    .frame(minWidth: proxy.size.width / 2)
+            }
+            .frame(height: proxy.size.height, alignment: .center)
+        }
+        .onSubmit {
+            menuItem.value = editingValue
+            restartApp = menuItem.requiresRestart
+        }
+        .restartApp($restartApp)
+        .onAppear {
+            editingValue = menuItem.value
+        }
+    }
+}

--- a/Sources/Spices/Spice.swift
+++ b/Sources/Spices/Spice.swift
@@ -102,6 +102,27 @@ import Foundation
         )
     }
 
+    /// Initializes a `Spice` property wrapper for a string setting.
+    /// - Parameters:
+    ///   - wrappedValue: The initial value of the string setting.
+    ///   - key: The key used to store the setting in UserDefaults. Defaults to a key generated from the property name.
+    ///   - name: The display name of the setting. Defaults to a formatted version of the property name.
+    ///   - requiresRestart: Set to `true` to restart the application when changing the value. Defaults to `false`.
+    public init(
+        wrappedValue: Value,
+        key: String? = nil,
+        name: String? = nil,
+        requiresRestart: Bool = false
+    ) where Value == String {
+        self.name = Name(name)
+        self.storage = AnyStorage(UserDefaultsStorage(default: wrappedValue, key: key))
+        self.menuItem = TextFieldMenuItem(
+            name: self.name,
+            requiresRestart: requiresRestart,
+            storage: self.storage
+        )
+    }
+
     /// Initializes a `Spice` property wrapper for an enum setting.
     /// - Parameters:
     ///   - wrappedValue: The initial value of the enum setting.

--- a/Tests/SpicesTests/Mocks/MockSpiceStore.swift
+++ b/Tests/SpicesTests/Mocks/MockSpiceStore.swift
@@ -5,6 +5,7 @@ final class MockSpiceStore: SpiceStore {
     nonisolated(unsafe) static var asynButtonClosureCalled = false
 
     @Spice var boolValue = false
+    @Spice var textValue = "Hello"
     @Spice var enumValue: MockEnvironment = .production
     @Spice var buttonValue = {
         MockSpiceStore.buttonClosureCalled = true

--- a/Tests/SpicesTests/SpiceTests.swift
+++ b/Tests/SpicesTests/SpiceTests.swift
@@ -35,6 +35,14 @@ final class SpiceTests {
         #expect(sut.userDefaults.string(forKey: "enumValue") == MockEnvironment.staging.rawValue)
     }
 
+    @Test func it_stores_string_value_in_user_defaults() {
+        let sut = MockSpiceStore()
+        sut.userDefaults.removeAll()
+        #expect(sut.userDefaults.object(forKey: "textValue") == nil)
+        sut.textValue = "Test value"
+        #expect(sut.userDefaults.string(forKey: "textValue") == "Test value")
+    }
+
     @Test func it_stores_button_closure() throws {
         let sut = MockSpiceStore()
         sut.userDefaults.removeAll()


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds a default text field view in the editor and supports reading/writing String settings from UserDefaults

## Motivation and Context

We would like to adopt this, but we have several settings like local testing API endpoints that can be dynamic through ngrok.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 16 Pro - 2025-02-25 at 10 40 54](https://github.com/user-attachments/assets/236c897b-36a6-4fa5-ae43-a58f6d981e9b)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
