### PR TITLE
Better support for initialisms in spice names

### DIFF
--- a/Sources/Spices/Internal/String+Helpers.swift
+++ b/Sources/Spices/Internal/String+Helpers.swift
@@ -8,17 +8,33 @@ extension String {
         return String(dropFirst(prefix.count))
     }
 
+    /// Split into camel case words, preserving initialisms like URL and HTTP.
     func camelCaseToNaturalText() -> String {
-        var result = ""
-        for (idx, scalar) in unicodeScalars.enumerated() {
+        var pieces = [String]()
+        var currentPiece = ""
+
+        for (idx, character) in enumerated() {
             if idx == 0 {
-                result += String(scalar).uppercased()
-            } else if CharacterSet.uppercaseLetters.contains(scalar) {
-                result += " \(String(scalar).uppercased())"
+                currentPiece += character.uppercased()
+            } else if character.isUppercase {
+                // Small check: recognize runs of multiple uppercase letters and
+                // consider them part of the same word.
+                if let previousChar = currentPiece.last, previousChar.isUppercase {
+                    currentPiece.append(character)
+                } else {
+                    pieces.append(currentPiece)
+                    currentPiece = character.uppercased()
+                }
             } else {
-                result += String(scalar)
+                currentPiece.append(character)
             }
         }
-        return result
+
+        // Commit the last bit of the phrase
+        if !currentPiece.isEmpty {
+            pieces.append(currentPiece)
+        }
+
+        return pieces.joined(separator: " ")
     }
 }

--- a/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
+++ b/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Testing
+
+@testable import Spices
+
+@Suite
+struct CamelCaseToNaturalTextTests {
+    @Test
+    func it_handles_simple_cases() async throws {
+        #expect("simpleName".camelCaseToNaturalText() == "Simple Name")
+        #expect("useLocalURL".camelCaseToNaturalText() == "Use Local URL")
+        #expect("environment".camelCaseToNaturalText() == "Environment")
+        #expect("enableLogging".camelCaseToNaturalText() == "Enable Logging")
+        #expect("clearCache".camelCaseToNaturalText() == "Clear Cache")
+        #expect("featureFlags".camelCaseToNaturalText() == "Feature Flags")
+        #expect("notifications".camelCaseToNaturalText() == "Notifications")
+        #expect("fastRefreshWidgets".camelCaseToNaturalText() == "Fast Refresh Widgets")
+
+        // Suboptimal, but heuristics for these would be annoying.
+        #expect("httpVersion".camelCaseToNaturalText() == "Http Version")
+        #expect("apiURL".camelCaseToNaturalText() == "Api URL")
+    }
+}


### PR DESCRIPTION
## Description

This improves handling for multiple sequenced uppercase characters in spice names when formatting for display.

## Motivation and Context

Right now all uppercase characters are being treated as word boundaries, which is sub-optimal. It causes property names like "localURL" to become "Local U R L", necessitating overrides for all the properties.

This new implementation keeps multiple uppercase characters together as a single word, and splits instead on the boundary where an uppercase character is introduced after a lowercase one.

This does a better job of preserving initialisms, but doesn't properly handle initialisms at the start of the spice name. I'm not sure a great solution for that, so clients should just override those where appropriate.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
