### PR TITLE
Handle title case words after initialisms

### DIFF
--- a/Sources/Spices/Internal/String+Helpers.swift
+++ b/Sources/Spices/Internal/String+Helpers.swift
@@ -13,13 +13,21 @@ extension String {
         var pieces = [String]()
         var currentPiece = ""
 
-        for (idx, character) in enumerated() {
-            if idx == 0 {
+        for (idx, character) in zip(indices, self) {
+            if idx == startIndex {
                 currentPiece += character.uppercased()
             } else if character.isUppercase {
                 // Small check: recognize runs of multiple uppercase letters and
-                // consider them part of the same word.
-                if let previousChar = currentPiece.last, previousChar.isUppercase {
+                // consider them part of the same word until the start of the next word.
+                let previousIndex = index(before: idx)
+                let nextIndex = index(after: idx)
+                let previous = self[previousIndex]
+                let next = nextIndex < endIndex ? self[nextIndex] : nil
+
+                // If the previous letter was uppercase, continue the initialism. However,
+                // if the next character is lowercase, it's the start of the next camel-case word,
+                // so don't include it in the run.
+                if previous.isUppercase && next?.isLowercase == true {
                     currentPiece.append(character)
                 } else {
                     pieces.append(currentPiece)

--- a/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
+++ b/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
@@ -15,6 +15,7 @@ struct CamelCaseToNaturalTextTests {
         #expect("featureFlags".camelCaseToNaturalText() == "Feature Flags")
         #expect("notifications".camelCaseToNaturalText() == "Notifications")
         #expect("fastRefreshWidgets".camelCaseToNaturalText() == "Fast Refresh Widgets")
+        #expect("ignoreNextHTTPRequest".camelCaseToNaturalText() == "Ignore Next HTTP Request")
 
         // Suboptimal, but heuristics for these would be annoying.
         #expect("httpVersion".camelCaseToNaturalText() == "Http Version")


### PR DESCRIPTION
## Description
This was a case I missed in my previous implementation.

Handle things like "HTTPRequest" splitting properly into "HTTP Request"

## Motivation and Context

The previous implementation would have split this into `"HTTPR Equest"

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
