### PR TITLE
Ensures observers receive correct initial value

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,9 @@ class ContentViewController: UIViewController {
 }
 ```
 
+> [!IMPORTANT]
+> If an observation is setup the corresponding property has been read or written, you must explicitly call `prepareIfNeeded()` on the spice store to avoid accessing an unprepared state. If the SpiceStore is not prepared, accessing a projected value will trigger an assertion failure.
+
 ## 🧪 Example Projects
 
 The example projects in the [Examples](/Examples) folder shows how Spices can be used to add an in-app debug menu to iOS apps with SwiftUI and UIKit lifecycles.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ class ContentViewController: UIViewController {
 ```
 
 > [!IMPORTANT]
-> If an observation is setup the corresponding property has been read or written, you must explicitly call `prepareIfNeeded()` on the spice store to avoid accessing an unprepared state. If the SpiceStore is not prepared, accessing a projected value will trigger an assertion failure.
+> If an observation is setup before the corresponding property has been read or written, you must explicitly call `prepareIfNeeded()` on the spice store to avoid accessing an unprepared state. If the SpiceStore is not prepared, accessing a projected value will trigger an assertion failure.
 
 ## 🧪 Example Projects
 

--- a/Sources/Spices/Internal/Storage/AnyStorage.swift
+++ b/Sources/Spices/Internal/Storage/AnyStorage.swift
@@ -1,53 +1,33 @@
 import Combine
 
 final class AnyStorage<Value>: ObservableObject {
+    private(set) var isPrepared = false
     let publisher: AnyPublisher<Value, Never>
     var value: Value {
         get {
-            backingValue
+            read()
         }
         set {
+            objectWillChange.send()
             write(newValue)
-            backingValue = newValue
         }
     }
 
     private let read: () -> Value
     private let write: (Value) -> Void
     private let prepare: (String, any SpiceStore) -> Void
-    private var cancellables: Set<AnyCancellable> = []
-    @Published private var backingValue: Value
 
-    convenience init<S: Storage>(_ storage: S) where S.Value == Value {
-        self.init(storage: storage)
-        storage.publisher.sink { [weak self] newValue in
-            self?.backingValue = newValue
-        }
-        .store(in: &cancellables)
-    }
-
-    convenience init<S: Storage>(_ storage: S) where S.Value == Value, S.Value: Equatable {
-        self.init(storage: storage)
-        // Remove duplicates to reduce publishes from updating backing value,
-        // ultimately reducing number of view updates.
-        storage.publisher.removeDuplicates().sink { [weak self] newValue in
-            self?.backingValue = newValue
-        }
-        .store(in: &cancellables)
-    }
-
-    private init<S: Storage>(storage: S) where S.Value == Value {
-        publisher = storage.publisher
-        backingValue = storage.value
+    init<S: Storage>(_ storage: S) where S.Value == Value {
         read = { storage.value }
         write = { storage.value = $0 }
         prepare = { storage.prepare(propertyName: $0, ownedBy: $1) }
+        publisher = storage.publisher
     }
 }
 
 extension AnyStorage: Preparable {
     func prepare(propertyName: String, ownedBy spiceStore: any SpiceStore) {
         prepare(propertyName, spiceStore)
-        backingValue = read()
+        isPrepared = true
     }
 }

--- a/Sources/Spices/Spice.swift
+++ b/Sources/Spices/Spice.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Combine
 import Foundation
 import SwiftUI
@@ -74,6 +75,7 @@ import SwiftUI
     /// }
     /// ```
     public var projectedValue: AnyPublisher<Value, Never> {
+        // swiftlint:disable:next line_length
         assert(storage.isPrepared, "The projected value of a Spice cannot be accessed until its owning spice store has been prepared. This happens automatically unless the projected value is accessed before the property has been read or written, in which case you must manually call prepareIfNeeded() on the spice store.")
         return storage.publisher
     }
@@ -482,3 +484,4 @@ private extension Spice {
 }
 
 extension Spice: MenuItemProvider {}
+// swiftlint:enable file_length

--- a/Sources/Spices/Spice.swift
+++ b/Sources/Spices/Spice.swift
@@ -74,7 +74,8 @@ import SwiftUI
     /// }
     /// ```
     public var projectedValue: AnyPublisher<Value, Never> {
-        storage.publisher
+        assert(storage.isPrepared, "The projected value of a Spice cannot be accessed until its owning spice store has been prepared. This happens automatically unless the projected value is accessed before the property has been read or written, in which case you must manually call prepareIfNeeded() on the spice store.")
+        return storage.publisher
     }
 
     let name: Name
@@ -158,7 +159,7 @@ import SwiftUI
         key: String? = nil,
         name: String? = nil,
         requiresRestart: Bool = false
-    ) where Value: RawRepresentable & CaseIterable {
+    ) where Value: RawRepresentable & CaseIterable, Value.RawValue: Equatable {
         self.name = Name(name)
         self.storage = AnyStorage(UserDefaultsStorage(default: wrappedValue, key: key))
         self.menuItem = PickerMenuItem(

--- a/Sources/Spices/SpiceStore.swift
+++ b/Sources/Spices/SpiceStore.swift
@@ -41,6 +41,27 @@ public extension SpiceStore {
     }
 }
 
+public extension SpiceStore {
+    /// Ensures that the `SpiceStore` is prepared before accessing its projected values.
+    ///
+    /// This method checks whether the `SpiceStore` has already been prepared. If not, it marks it as prepared
+    /// and invokes the `prepare()` method.
+    ///
+    /// You typically do not need to call this method manually, as preparation happens automatically. However,
+    /// if ``Spice/projectedValue`` is accessed before the corresponding property has been read or written,
+    /// you must explicitly call `prepareIfNeeded()` to avoid accessing an unprepared state.
+    ///
+    /// - Important: If the `SpiceStore` is not prepared, accessing a projected value will trigger an assertion failure.
+    ///
+    func prepareIfNeeded() {
+        guard !isPrepared else {
+            return
+        }
+        isPrepared = true
+        prepare()
+    }
+}
+
 extension SpiceStore {
     var id: String {
         if let value = objc_getAssociatedObject(self, &idKey) as? String {
@@ -106,14 +127,6 @@ extension SpiceStore {
         let publisher = objectWillChange as? ObservableObjectPublisher
         publisher?.send()
         parent?.publishObjectWillChange()
-    }
-
-    func prepareIfNeeded() {
-        guard !isPrepared else {
-            return
-        }
-        isPrepared = true
-        prepare()
     }
 
     private func prepare() {

--- a/Sources/Spices/Spices.docc/Extensions/SpiceStore.md
+++ b/Sources/Spices/Spices.docc/Extensions/SpiceStore.md
@@ -1,0 +1,11 @@
+# ``SpiceStore``
+
+## Topics
+
+### Storage
+
+- ``SpiceStore/userDefaults``
+
+### Preparation
+
+- ``SpiceStore/prepareIfNeeded()``

--- a/Tests/SpicesTests/AnyStorageTests.swift
+++ b/Tests/SpicesTests/AnyStorageTests.swift
@@ -1,0 +1,46 @@
+import Combine
+import Foundation
+import Testing
+@testable import Spices
+
+@Suite
+final class AnyStorageTests {
+    private var cancellables: Set<AnyCancellable> = []
+
+    @Test
+    func it_reads_value() async throws {
+        let storage = MockStorage(default: "Hello world!")
+        let sut = AnyStorage(storage)
+        #expect(sut.value == "Hello world!")
+    }
+
+    @Test
+    func it_writes_value() async throws {
+        let storage = MockStorage(default: "Hello world!")
+        let sut = AnyStorage(storage)
+        sut.value = "Foo"
+        #expect(storage.value == "Foo")
+    }
+
+    @Test
+    func it_notifies_observer_of_changes() async throws {
+        let storage = MockStorage(default: "Hello world!")
+        let sut = AnyStorage(storage)
+        var didReceiveChange = false
+        sut.objectWillChange.sink {
+            didReceiveChange = true
+        }
+        .store(in: &cancellables)
+        sut.value = "Foo"
+        #expect(didReceiveChange == true)
+    }
+
+    @Test
+    func it_updates_prepared_state() async throws {
+        let storage = MockStorage(default: "Hello world!")
+        let sut = AnyStorage(storage)
+        #expect(sut.isPrepared == false)
+        sut.prepare(propertyName: "foo", ownedBy: MockSpiceStore())
+        #expect(sut.isPrepared == true)
+    }
+}

--- a/Tests/SpicesTests/AnyStorageTests.swift
+++ b/Tests/SpicesTests/AnyStorageTests.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
-import Testing
 @testable import Spices
+import Testing
 
 @Suite
 final class AnyStorageTests {

--- a/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
+++ b/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Testing
 @testable import Spices
+import Testing
 
 @Suite
 struct CamelCaseToNaturalTextTests {

--- a/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
+++ b/Tests/SpicesTests/CamelCaseToNaturalTextTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Testing
-
 @testable import Spices
 
 @Suite

--- a/Tests/SpicesTests/Mocks/MockStorage.swift
+++ b/Tests/SpicesTests/Mocks/MockStorage.swift
@@ -1,0 +1,24 @@
+import Combine
+@testable import Spices
+
+final class MockStorage<Value>: Storage, Preparable {
+    var publisher: AnyPublisher<Value, Never> {
+        subject.eraseToAnyPublisher()
+    }
+    var value: Value {
+        get {
+            subject.value
+        }
+        set {
+            subject.send(newValue)
+        }
+    }
+
+    private let subject: CurrentValueSubject<Value, Never>
+
+    init(default value: Value) {
+        subject = CurrentValueSubject(value)
+    }
+
+    func prepare(propertyName: String, ownedBy spiceStore: any SpiceStore) {}
+}

--- a/Tests/SpicesTests/SpiceTests.swift
+++ b/Tests/SpicesTests/SpiceTests.swift
@@ -3,7 +3,7 @@ import Foundation
 @testable import Spices
 import Testing
 
-@MainActor @Suite
+@MainActor @Suite(.serialized)
 final class SpiceTests {
     private var cancellables: Set<AnyCancellable> = []
 

--- a/Tests/SpicesTests/SpiceTests.swift
+++ b/Tests/SpicesTests/SpiceTests.swift
@@ -63,6 +63,7 @@ final class SpiceTests {
         var initialValue: MockEnvironment?
         let sut = MockSpiceStore()
         sut.userDefaults.removeAll()
+        sut.prepareIfNeeded()
         sut.$enumValue.sink { newValue in
             initialValue = newValue
         }
@@ -70,10 +71,24 @@ final class SpiceTests {
         #expect(initialValue == .production)
     }
 
+    @Test func it_sink_receives_initial_value_if_it_has_been_changed() async throws {
+        var initialValue: MockEnvironment?
+        let sut = MockSpiceStore()
+        sut.userDefaults.removeAll()
+        sut.userDefaults.set(MockEnvironment.staging.rawValue, forKey: "enumValue")
+        sut.prepareIfNeeded()
+        sut.$enumValue.sink { newValue in
+            initialValue = newValue
+        }
+        .store(in: &cancellables)
+        #expect(initialValue == .staging)
+    }
+
     @Test func it_publishes_values() async throws {
         var publishedValue: MockEnvironment?
         let sut = MockSpiceStore()
         sut.userDefaults.removeAll()
+        sut.prepareIfNeeded()
         sut.$enumValue.sink { newValue in
             publishedValue = newValue
         }

--- a/Tests/SpicesTests/UserDefaultsStorageTests.swift
+++ b/Tests/SpicesTests/UserDefaultsStorageTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Testing
 @testable import Spices
 
-@MainActor @Suite
+@MainActor @Suite(.serialized)
 final class UserDefaultsStorageTests {
     @Test
     func it_returns_default_value() async throws {

--- a/Tests/SpicesTests/UserDefaultsStorageTests.swift
+++ b/Tests/SpicesTests/UserDefaultsStorageTests.swift
@@ -1,7 +1,7 @@
 import Combine
 import Foundation
-import Testing
 @testable import Spices
+import Testing
 
 @MainActor @Suite(.serialized)
 final class UserDefaultsStorageTests {
@@ -55,14 +55,14 @@ final class UserDefaultsStorageTests {
     func it_publishes_initial_value() async throws {
         let spiceStore = MockSpiceStore()
         spiceStore.userDefaults.removeAll()
-        spiceStore.userDefaults.set(true, forKey: "foo")
-        let sut = UserDefaultsStorage(default: false, key: nil)
+        spiceStore.userDefaults.set("Hello world!", forKey: "foo")
+        let sut = UserDefaultsStorage(default: "default", key: nil)
         sut.prepare(propertyName: "foo", ownedBy: spiceStore)
-        var readValue: Bool?
+        var readValue: String?
         _ = sut.publisher.sink { value in
             readValue = value
         }
-        #expect(readValue == true)
+        #expect(readValue == "Hello world!")
     }
 
     @Test

--- a/Tests/SpicesTests/UserDefaultsStorageTests.swift
+++ b/Tests/SpicesTests/UserDefaultsStorageTests.swift
@@ -5,6 +5,8 @@ import Testing
 
 @MainActor @Suite(.serialized)
 final class UserDefaultsStorageTests {
+    private var cancellables: Set<AnyCancellable> = []
+
     @Test
     func it_returns_default_value() async throws {
         let spiceStore = MockSpiceStore()
@@ -61,5 +63,126 @@ final class UserDefaultsStorageTests {
             readValue = value
         }
         #expect(readValue == true)
+    }
+
+    @Test
+    func it_publishes_valuyes() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "foo", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        let _: Void = try await withCheckedThrowingContinuation { @MainActor continuation in
+            let timeoutTask = Task {
+                // Wait for a second and if that time passes, assume we will not get notified,
+                // in which case the test succeeded.
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                continuation.resume()
+            }
+            sut.publisher.sink { value in
+                if value == "bar" {
+                    // We received the new value, so all is good.
+                    timeoutTask.cancel()
+                    continuation.resume()
+                }
+            }
+            .store(in: &cancellables)
+            // Setting the same value. This should not result in a value being published.
+            sut.value = "bar"
+        }
+    }
+
+    @Test
+    func it_skips_publishing_same_value() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "foo", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        let _: Void = try await withCheckedThrowingContinuation { @MainActor continuation in
+            let timeoutTask = Task {
+                // Wait for a second and if that time passes, assume we will not get notified,
+                // in which case the test succeeded.
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                continuation.resume()
+            }
+            var count = 0
+            sut.publisher.sink { value in
+                count += 1
+                if count == 1 {
+                    // This is the initial value received upon subscribing.
+                } else if count == 2 {
+                    // This is the second value. We did not expect this, so throw an error.
+                    timeoutTask.cancel()
+                    let error = NSError(domain: "dk.shape.Spices", code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: "Received unexpected value: \(value)"
+                    ])
+                    continuation.resume(throwing: error)
+                }
+            }
+            .store(in: &cancellables)
+            // Setting the same value. This should not result in a value being published.
+            sut.value = "foo"
+        }
+    }
+
+    @Test
+    func it_publishes_when_user_defaults_change() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "foo", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        let _: Void = try await withCheckedThrowingContinuation { @MainActor continuation in
+            let timeoutTask = Task {
+                // Wait for a second and if that time passes, assume we will not get notified,
+                // in which case we throw an error as the test has failed.
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                let error = NSError(domain: "dk.shape.Spices", code: -1, userInfo: [
+                    NSLocalizedDescriptionKey: "Operation timed out"
+                ])
+                continuation.resume(throwing: error)
+            }
+            sut.publisher.sink { value in
+                if value == "bar" {
+                    // We received the new value, so all is good.
+                    timeoutTask.cancel()
+                    continuation.resume()
+                }
+            }
+            .store(in: &cancellables)
+            // Updating UserDefaults should cause a value to be published.
+            spiceStore.userDefaults.set("bar", forKey: "foo")
+        }
+    }
+
+    @Test
+    func it_skips_publishing_when_user_defaults_is_updated_with_same_value() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "foo", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        let _: Void = try await withCheckedThrowingContinuation { @MainActor continuation in
+            let timeoutTask = Task {
+                // Wait for a second and if that time passes, assume we will not get notified,
+                // in which case the test succeeded.
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                continuation.resume()
+            }
+            var count = 0
+            sut.publisher.sink { value in
+                count += 1
+                if count == 1 {
+                    // This is the initial value received upon subscribing.
+                } else if count == 2 {
+                    // This is the second value. We did not expect this, so throw an error.
+                    timeoutTask.cancel()
+                    let error = NSError(domain: "dk.shape.Spices", code: -1, userInfo: [
+                        NSLocalizedDescriptionKey: "Received unexpected value: \(value)"
+                    ])
+                    continuation.resume(throwing: error)
+                }
+            }
+            .store(in: &cancellables)
+            // Assign the same value as we currentl have in user defaults.
+            spiceStore.userDefaults.set("foo", forKey: "foo")
+        }
     }
 }

--- a/Tests/SpicesTests/UserDefaultsStorageTests.swift
+++ b/Tests/SpicesTests/UserDefaultsStorageTests.swift
@@ -1,0 +1,65 @@
+import Combine
+import Foundation
+import Testing
+@testable import Spices
+
+@MainActor @Suite
+final class UserDefaultsStorageTests {
+    @Test
+    func it_returns_default_value() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "default", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        #expect(sut.value == "default")
+    }
+
+    @Test
+    func it_stores_value_under_property_name() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "default", key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        sut.value = "Hello world!"
+        #expect(spiceStore.userDefaults.string(forKey: "foo") == "Hello world!")
+    }
+
+    @Test
+    func it_stores_value_under_provided_key() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = UserDefaultsStorage(default: "default", key: "bar")
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        sut.value = "Hello world!"
+        #expect(spiceStore.userDefaults.string(forKey: "bar") == "Hello world!")
+    }
+
+    @Test
+    func it_stores_raw_representable_values() async throws {
+        func makeStorage<Value: RawRepresentable & CaseIterable>(
+            default defaultValue: Value
+        ) -> UserDefaultsStorage<Value> where Value.RawValue: Equatable {
+            UserDefaultsStorage(default: defaultValue, key: nil)
+        }
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        let sut = makeStorage(default: MockEnvironment.production)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        sut.value = MockEnvironment.staging
+        #expect(spiceStore.userDefaults.string(forKey: "foo") == "staging")
+    }
+
+    @Test
+    func it_publishes_initial_value() async throws {
+        let spiceStore = MockSpiceStore()
+        spiceStore.userDefaults.removeAll()
+        spiceStore.userDefaults.set(true, forKey: "foo")
+        let sut = UserDefaultsStorage(default: false, key: nil)
+        sut.prepare(propertyName: "foo", ownedBy: spiceStore)
+        var readValue: Bool?
+        _ = sut.publisher.sink { value in
+            readValue = value
+        }
+        #expect(readValue == true)
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The changes in this PR ensure that observers installed with `spiceStore.$myValue.sink { ... }` receive the correct value upon subscribing rather than the default value of the spice.

The value can only be provided when the spice store has been prepared, which happens automatically when reading or writing the value of a spice (e.g., ` _ = spiceStore.myValue` or `spiceStore.myValue = newValue`), but not when accessing the projected value (`spiceStore.$myValue`).

As a result, `prepareIfNeeded()` has been made public, enabling users of Spices to call the function prior to setting up an observer. This is only needed once.

In order to enforce that `prepareIfNeeded()` is called, `projectedValue` on a Spice will assert if the underlying storage has not been prepared.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prior to these changes, observers set up with `spiceStore.$myValue` would receive an incorrect value upon subscribing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
