### PR TITLE
Remove misleading assertion in Spice type

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,6 @@ class ContentViewController: UIViewController {
 }
 ```
 
-> [!IMPORTANT]
-> If an observation is setup before the corresponding property has been read or written, you must explicitly call `prepareIfNeeded()` on the spice store to avoid accessing an unprepared state. If the SpiceStore is not prepared, accessing a projected value will trigger an assertion failure.
-
 ## 🧪 Example Projects
 
 The example projects in the [Examples](/Examples) folder shows how Spices can be used to add an in-app debug menu to iOS apps with SwiftUI and UIKit lifecycles.

--- a/Sources/Spices/Spice.swift
+++ b/Sources/Spices/Spice.swift
@@ -75,9 +75,7 @@ import SwiftUI
     /// }
     /// ```
     public var projectedValue: AnyPublisher<Value, Never> {
-        // swiftlint:disable:next line_length
-        assert(storage.isPrepared, "The projected value of a Spice cannot be accessed until its owning spice store has been prepared. This happens automatically unless the projected value is accessed before the property has been read or written, in which case you must manually call prepareIfNeeded() on the spice store.")
-        return storage.publisher
+        storage.publisher
     }
 
     let name: Name

--- a/Tests/SpicesTests/UserDefaultsStorageTests.swift
+++ b/Tests/SpicesTests/UserDefaultsStorageTests.swift
@@ -66,7 +66,7 @@ final class UserDefaultsStorageTests {
     }
 
     @Test
-    func it_publishes_valuyes() async throws {
+    func it_publishes_values() async throws {
         let spiceStore = MockSpiceStore()
         spiceStore.userDefaults.removeAll()
         let sut = UserDefaultsStorage(default: "foo", key: nil)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This removes the assert in `Spice` that was warning developers to call `prepareIfNeeded()` too early. That assertion didn’t accurately reflect how nested spice stores initialize and led to incorrect user defaults key paths.

## Description
<!--- Describe your changes in detail -->

Setting up an observer in the initializer of a nested `SpiceStore` will trigger the assert before the parent–child relationship is wired up. Developers will work around this by calling `prepareIfNeeded()` too early, which results in an incorrect key path for the child spice.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Consider the following scenario.

```swift
enum ServiceEnvironment: String, CaseIterable {
    case production
    case staging
}

final class AppSpiceStore: SpiceStore {
    @Spice(name: "🍃 Environment") var environment = EnvironmentSpiceStore()
}

final class EnvironmentSpiceStore: SpiceStore {
    @Spice(requiresRestart: true) var appService: ServiceEnvironment = .production

    private var cancellables: Set<AnyCancellable> = []

    init() {
        $appService
            .removeDuplicates()
            .dropFirst()
            .sink { _ in }
            .store(in: &cancellables)
    }
}
```

Accessing `$appService` here triggers our assertion. That happens because initializing `EnvironmentSpiceStore` installs the Combine observer on `appService` before the spice store's parent–child relationship is set up. Developers then try to work around the assert by calling `prepareIfNeeded()` in the child's initializer. This causes the child spice to use the wrong user defaults key, since its fully qualified key path isn’t known yet, ultimately making it appear that the value isn't properly saved because it's saved under an incorrect key.

Removing the assertion makes this pattern valid. The nested store will be prepared automatically when its parent is ready.

If we ever find ourselves needing this assert again, we should likely address it differently.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
