### PR TITLE
Add onAppear event for SpiceStore

### DIFF
--- a/Examples/SwiftUIExample/AppSpiceStore.swift
+++ b/Examples/SwiftUIExample/AppSpiceStore.swift
@@ -22,6 +22,11 @@ final class AppSpiceStore: SpiceStore {
     }
     .padding()
     @Spice var version = LabeledContent("Version", value: "1.0 (1)")
+    @Spice var userId: String = "Not loaded"
+
+    func onAppear() {
+        userId = "\(Int.random(in: 0...100))"
+    }
 }
 
 final class DebuggingSpiceStore: SpiceStore {

--- a/Examples/UIKitExample/AppSpiceStore.swift
+++ b/Examples/UIKitExample/AppSpiceStore.swift
@@ -25,8 +25,13 @@ final class AppSpiceStore: SpiceStore {
     }
     .padding()
     @Spice var version = LabeledContent("Version", value: "1.0 (1)")
+    @Spice var userId: String = "Not loaded"
 
     private init() {}
+
+    func onAppear() {
+        userId = "\(Int.random(in: 0...100))"
+    }
 }
 
 final class DebuggingSpiceStore: SpiceStore {

--- a/Sources/Spices/SpiceEditor.swift
+++ b/Sources/Spices/SpiceEditor.swift
@@ -68,6 +68,9 @@ public struct SpiceEditor: View {
             MenuItemListView(items: spiceStore.menuItems, title: title) {
                 dismiss()
             }
+            .onAppear {
+                spiceStore.onAppear()
+            }
         }
         .configureSheetPresentation()
         .environmentObject(UserInteraction())

--- a/Sources/Spices/SpiceStore.swift
+++ b/Sources/Spices/SpiceStore.swift
@@ -33,11 +33,17 @@ public protocol SpiceStore: AnyObject, ObservableObject {
     ///
     /// The default implementation returns `UserDefaults.standard`.
     var userDefaults: UserDefaults { get }
+    
+    /// Call when the store appear on the screen
+    func onAppear()
 }
 
 public extension SpiceStore {
     var userDefaults: UserDefaults {
         .standard
+    }
+    
+    func onAppear() {
     }
 }
 


### PR DESCRIPTION
## Description
Add a new protocol method inside the Store for updating the Spice when the View appear.

## Motivation and Context
Currently, the _Spice_ are set only once, when the init is called.
Sometimes, some values can change during the lifetime of the application.

For example, the FCM/APNS token can change during the lifetime of the application.

So, by adding the possibility to update the value dynamically, the debug menu is more useful.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
